### PR TITLE
add support for the 'mmm'->'Jan' format

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -67,6 +67,8 @@ type MonthFormatter struct {
 
 func (self *MonthFormatter) translateToGolangFormat() (string, error) {
 	switch len(self.origin) {
+	case 3:
+		return "Jan", nil
 	case 2:
 		return "01", nil
 	case 1:

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,31 +1,30 @@
 package yymmdd
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
 
-func TestParseYY(t *testing.T) {
-	_, tokens := Lexer(`yy-`)
-	ds := Parse(tokens)
-	fmt.Println(ds.Format(time.Now()))
+var date = time.Date(2018, time.March, 15, 12, 0, 0, 0, time.UTC)
+
+var tests = []struct {
+	format   string
+	expected string
+}{
+	{"yy-", "18-"},
+	{"yyyymm", "201803"},
+	{"yyyy-mm", "2018-03"},
+	{"mmm yyyy", "Mar 2018"},
+	{"yyyy-mm-dd", "2018-03-15"},
 }
 
-func TestParseMM(t *testing.T) {
-	_, tokens := Lexer(`yyyymm`)
-	ds := Parse(tokens)
-	fmt.Println(ds.Format(time.Now()))
-}
-
-func TestParseMM2(t *testing.T) {
-	_, tokens := Lexer(`yyyy-mm`)
-	ds := Parse(tokens)
-	fmt.Println(ds.Format(time.Now()))
-}
-
-func TestParseDD(t *testing.T) {
-	_, tokens := Lexer(`yyyy-mm-dd`)
-	ds := Parse(tokens)
-	fmt.Println(ds.Format(time.Now()))
+func TestParse(t *testing.T) {
+	for i, testCase := range tests {
+		_, tokens := Lexer(testCase.format)
+		ds := Parse(tokens)
+		actual := ds.Format(date)
+		if actual != testCase.expected {
+			t.Errorf("Case index %d failed. Expected: %s, Got: %s", i, testCase.expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
I needed to parse the "mmm" format from an xls spreadsheet, but it wasn't supported by goyymmdd, so I've added that (and reformatted the tests).

Thanks for the great library!